### PR TITLE
2.0.3 - Fix initial index building

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ npm install @peardrive/core
 
 ## 🚧 Changelog
 
+### 2.0.3
+
+- Fix bug preventing files from being added to the hyperbee when a watchPath is initialized for the first time when already populated with files
+
 ### 2.0.2
 
 - Public release

--- a/package-lock.json
+++ b/package-lock.json
@@ -929,13 +929,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
-      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "version": "24.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
+      "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.12.0"
+        "undici-types": "~7.13.0"
       }
     },
     "node_modules/@types/unist": {
@@ -1009,9 +1009,9 @@
       "license": "Python-2.0"
     },
     "node_modules/b4a": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.2.tgz",
-      "integrity": "sha512-DyUOdz+E8R6+sruDpQNOaV0y/dBbV6X/8ZkxrDcR0Ifc3BgKlpgG0VAtfOozA0eMtJO5GGe9FsZhueLs00pTww==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -1093,9 +1093,9 @@
       }
     },
     "node_modules/bare-crypto": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/bare-crypto/-/bare-crypto-1.11.2.tgz",
-      "integrity": "sha512-frwW8a5ZeIzkg6jyjJ5g+yQQmsWa5DhLnRr92fsKQx00dA3aWU7zDLFg7Jlr5xNCvNhYElLI3Zd6u8cPj79ZOw==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/bare-crypto/-/bare-crypto-1.11.6.tgz",
+      "integrity": "sha512-CjNxA/7ewj4D1Rhp8RROtQNEjGKhByr8J6PcR8v9W9Hde3e9kT+tbBbBigHgkXGsDniwYIZJ16ccvRAOOgevPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-stream": "^2.6.3"
@@ -1170,9 +1170,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.4.4.tgz",
-      "integrity": "sha512-Q8yxM1eLhJfuM7KXVP3zjhBvtMJCYRByoTT+wHXjpdMELv0xICFJX+1w4c7csa+WZEOsq4ItJ4RGwvzid6m/dw==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.4.5.tgz",
+      "integrity": "sha512-TCtu93KGLu6/aiGWzMr12TmSRS6nKdfhAnzTQRbXoSWxkbb9eRd53jQ51jG7g1gYjjtto3hbBrrhzg6djcgiKg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -1699,9 +1699,9 @@
       "license": "MIT"
     },
     "node_modules/compact-encoding": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-2.16.1.tgz",
-      "integrity": "sha512-vP39X4nwtesmZucaAxDg4wnudOoaJTSR+fikzi8VLVxbwLmcWXf3t0LxY0n2H1AMpdoQZ08lmUf4GY3XiDPnMQ==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-2.17.0.tgz",
+      "integrity": "sha512-A5mkpopiDqCddAHTmJ/VnP7JQ1MCytRbpi13zQJGsDcKN041B++2n8oUwxBn37C86gbIt/zIARaqLVy9vI9M5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.3.0"
@@ -2359,9 +2359,9 @@
       }
     },
     "node_modules/hypercore-storage": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/hypercore-storage/-/hypercore-storage-1.14.1.tgz",
-      "integrity": "sha512-i8ktFfYyBrsNWsNXWG4OZdwm5ZOeSgcTJ14ZwSQ9Rz2HyjpdzAyEiPrUKNGdNXZhRyMnQkvHPnxD3HoE0NiDgQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/hypercore-storage/-/hypercore-storage-1.16.0.tgz",
+      "integrity": "sha512-QAxygUMi+5OCF8+nkmnfJQFc5xMUY8keGcavgd7cn/97xTqsUQbxLsmxHyG/vUTFqH2+cy6JuG2QnzLuPl3o7A==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.7",
@@ -2380,9 +2380,9 @@
       }
     },
     "node_modules/hyperdht": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.23.0.tgz",
-      "integrity": "sha512-MEdwpOr2axoprHoWJLO0/7Iux+l0BK9d76s8kpw/Eu9ABttk0wSQCC22NIMGoC03MIMhoSPF5u+TqaWaRMx3kw==",
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.24.0.tgz",
+      "integrity": "sha512-l9JEYaRzbfoB1HVgGYmOhhpbT2zX/SDj6NxS394Ing5je97HHG82EwrajOb7QX8kO8pIDVpF1+SdZo8u8vD0mg==",
       "license": "MIT",
       "dependencies": {
         "@hyperswarm/secret-stream": "^6.6.2",
@@ -2430,9 +2430,9 @@
       }
     },
     "node_modules/hyperschema": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/hyperschema/-/hyperschema-1.15.0.tgz",
-      "integrity": "sha512-ntkfz/3oGdbjhjBF70I0K7FKMT0JN4CxAa8h+QYZcupXtRYHjRsTM8J1yfFmcC4IdlmiUNaon86JVR0cb9UOMQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/hyperschema/-/hyperschema-1.16.0.tgz",
+      "integrity": "sha512-4IBhyRAZLJ5/6eUv415xizbbFCQKqwMPYl5DoUjFDyzpDGcvk104ENJGGmmmvCHa484k1cNyfrQ2RqLE/4+O6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-fs": "^4.0.1",
@@ -3315,9 +3315,9 @@
       }
     },
     "node_modules/sodium-native": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-5.0.8.tgz",
-      "integrity": "sha512-2ZxmF9Llvo/3X3NAc8VV6JFoswObg9u27Q8Be4BtCLDiejXuTt6Nm7+iIWUv+WMcs1eJ7YV5U2f4e8LidfIlRQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-5.0.9.tgz",
+      "integrity": "sha512-6fpu3d6zdrRpLhuV3CDIBO5g90KkgaeR+c3xvDDz0ZnDkAlqbbPhFW7zhMJfsskfZ9SuC3SvBbqvxcECkXRyKw==",
       "license": "MIT",
       "dependencies": {
         "require-addon": "^1.1.0",
@@ -3521,9 +3521,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3564,9 +3564,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
-      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
+      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@peardrive/core",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@peardrive/core",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@hopets/logger": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peardrive/core",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "./dist/PearDrive.js",
   "module": "./dist/PearDrive.js",
   "type": "module",

--- a/src/LocalFileIndex.js
+++ b/src/LocalFileIndex.js
@@ -662,16 +662,15 @@ export default class LocalFileIndex extends ReadyResource {
     });
     await this.#bee.ready();
 
+    // Load watchPath current state and metadata cache
     await this.#loadMetadataCache();
+    await this.buildIndex();
 
     // File polling / watching
     if (this._useNativeWatching) {
       await this.#startNativeWatching();
     } else {
       this.#log.info("Native file watching disabled, using polling mode.");
-    }
-    if (this._indexOpts.poll) {
-      this.startPolling();
     }
 
     this.#log.info("LocalFileIndex opened successfully!");


### PR DESCRIPTION
Files already present in watchPath weren't being appended to the hyperbee because the buildIndex function wasn't called in the _open lifecycle method